### PR TITLE
Add `sub_domains` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Available targets:
 | <a name="output_domain_association_arn"></a> [domain\_association\_arn](#output\_domain\_association\_arn) | ARN of the domain association |
 | <a name="output_domain_association_certificate_verification_dns_record"></a> [domain\_association\_certificate\_verification\_dns\_record](#output\_domain\_association\_certificate\_verification\_dns\_record) | The DNS record for certificate verification |
 | <a name="output_name"></a> [name](#output\_name) | Amplify App name |
+| <a name="output_sub_domains"></a> [sub\_domains](#output\_sub\_domains) | DNS records and the verified status for the subdomains |
 | <a name="output_webhooks"></a> [webhooks](#output\_webhooks) | Created webhooks |
 <!-- markdownlint-restore -->
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -84,5 +84,6 @@
 | <a name="output_domain_association_arn"></a> [domain\_association\_arn](#output\_domain\_association\_arn) | ARN of the domain association |
 | <a name="output_domain_association_certificate_verification_dns_record"></a> [domain\_association\_certificate\_verification\_dns\_record](#output\_domain\_association\_certificate\_verification\_dns\_record) | The DNS record for certificate verification |
 | <a name="output_name"></a> [name](#output\_name) | Amplify App name |
+| <a name="output_sub_domains"></a> [sub\_domains](#output\_sub\_domains) | DNS records and the verified status for the subdomains |
 | <a name="output_webhooks"></a> [webhooks](#output\_webhooks) | Created webhooks |
 <!-- markdownlint-restore -->

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -4,7 +4,7 @@ output "name" {
 }
 
 output "arn" {
-  description = "Amplify App ARN "
+  description = "Amplify App ARN"
   value       = module.amplify_app.arn
 }
 
@@ -36,4 +36,9 @@ output "domain_association_arn" {
 output "domain_association_certificate_verification_dns_record" {
   description = "The DNS record for certificate verification"
   value       = module.amplify_app.domain_association_certificate_verification_dns_record
+}
+
+output "sub_domains" {
+  description = "DNS records and the verified status for the subdomains"
+  value       = module.amplify_app.sub_domains
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "name" {
 }
 
 output "arn" {
-  description = "Amplify App ARN "
+  description = "Amplify App ARN"
   value       = one(aws_amplify_app.default[*].arn)
 }
 
@@ -36,4 +36,9 @@ output "domain_association_arn" {
 output "domain_association_certificate_verification_dns_record" {
   description = "The DNS record for certificate verification"
   value       = one(aws_amplify_domain_association.default[*].certificate_verification_dns_record)
+}
+
+output "sub_domains" {
+  description = "DNS records and the verified status for the subdomains"
+  value       = one(aws_amplify_domain_association.default[*].sub_domain)
 }


### PR DESCRIPTION
## what

* Add `sub_domains` output

## why

* Needed to create DNS CNAME records in the custom domain DNS zone to point to the Amplify app

```hcl
sub_domains = toset([
{
  "branch_name" = "dev"
  "dns_record" = "dev CNAME d3id0e13ftymve.cloudfront.net"
  "prefix" = "dev"
  "verified" = false
},
{
  "branch_name" = "main"
  "dns_record" = " CNAME d3id0e13ftymve.cloudfront.net"
  "prefix" = ""
  "verified" = false
},
])
```
