### PR TITLE
feat: BREAKING enable customization of cert for custom domains

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -95,22 +95,17 @@ resource "aws_amplify_branch" "default" {
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_domain_association
-resource "aws_amplify_domain_association" "default" {
+resource "awscc_amplify_domain" "default" {
   for_each = local.domains
 
-  app_id                 = one(aws_amplify_app.default[*].id)
-  domain_name            = each.key
-  enable_auto_sub_domain = lookup(each.value, "enable_auto_sub_domain", null)
-  wait_for_verification  = lookup(each.value, "wait_for_verification", null)
+  app_id              = one(aws_amplify_app.default[*].id)
+  domain_name         = each.key
+  sub_domain_settings = each.value.sub_domain_settings
 
-  dynamic "sub_domain" {
-    for_each = lookup(each.value, "sub_domain")
-
-    content {
-      branch_name = aws_amplify_branch.default[sub_domain.value.branch_name].branch_name
-      prefix      = sub_domain.value.prefix
-    }
-  }
+  auto_sub_domain_creation_patterns = each.value.auto_sub_domain_creation_patterns
+  auto_sub_domain_iam_role          = each.value.auto_sub_domain_iam_role
+  certificate_settings              = each.value.certificate_settings
+  enable_auto_sub_domain            = each.value.enable_auto_sub_domain
 }
 
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/amplify_webhook

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,5 +35,5 @@ output "webhooks" {
 
 output "domain_associations" {
   description = "Created domain associations"
-  value       = aws_amplify_domain_association.default
+  value       = awscc_amplify_domain.default
 }

--- a/variables.tf
+++ b/variables.tf
@@ -176,12 +176,19 @@ variable "environments" {
 
 variable "domains" {
   type = map(object({
-    enable_auto_sub_domain = optional(bool, false)
-    wait_for_verification  = optional(bool, false)
-    sub_domain = list(object({
+    sub_domain_settings = list(object({
       branch_name = string
       prefix      = string
     }))
+    auto_sub_domain_creation_patterns = optional(list(string))
+    auto_sub_domain_iam_role          = optional(string)
+    certificate_settings = optional(object({
+      certificate_type       = optional(string)
+      custom_certificate_arn = optional(string)
+      }), {
+      certificate_type = "AMPLIFY_MANAGED"
+    })
+    enable_auto_sub_domain = optional(bool)
   }))
   description = "Amplify custom domain configurations"
   default     = {}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,14 @@
 terraform {
-  required_version = ">= 1.3.0"
+  required_version = ">= 1.5.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
       version = ">= 4.0"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = ">= 0.78.0"
     }
   }
 }


### PR DESCRIPTION
## what

Enable users to set custom SSL attributes on amplify domains.
BREAKING: Switch `amplify_domain` resource to `awscc` provider to get access to additional attributes not present in `aws` provider.
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

I needed to use a custom certificate because I am deploying to a domain that exists in a different AWS account, therefore I could not let Amplify create the SSL cert.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
