### PR TITLE
fix: remove end of string space

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_amplify_branch" "default" {
   description                   = lookup(each.value, "description", null)
   enable_auto_build             = lookup(each.value, "enable_auto_build", null)
   enable_basic_auth             = lookup(each.value, "enable_basic_auth", null)
-  enable_notification           = lookup(each.value, "enable_notification ", null)
+  enable_notification           = lookup(each.value, "enable_notification", null)
   enable_performance_mode       = lookup(each.value, "enable_performance_mode", null)
   enable_pull_request_preview   = lookup(each.value, "enable_pull_request_preview", null)
   environment_variables         = lookup(each.value, "environment_variables", {})


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

As there is a whitespace before closing the quotes, when trying to enable notifications, Terraform always try to set it to `null`:

Code snippet:

```hcl
  environments = {
    main = {
      branch_name               = "main"
      enable_notification      = true
[...]
```

Output: 

```hcl
  # module.amplify_app.aws_amplify_branch.default["main"] will be updated in-place
  ~ resource "aws_amplify_branch" "default" {
      - enable_notification           = true -> null
        id                            = "xxxxxxxxxxxxxx/main"
        tags                          = {}
        # (21 unchanged attributes hidden)
    }
```


## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
